### PR TITLE
fix: 429 Too Many Requests por rate limit mal configurado

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,10 +4,19 @@ const db = require('./src/models');
 const cors = require('cors');
 const rateLimit = require('express-rate-limit');
 
+// La app corre detrás de un reverse proxy (Next.js rewrites / nginx). Sin esto,
+// req.ip sería la IP del proxy para TODOS los usuarios y el rate limit por IP
+// se convierte en un único cupo global compartido. Con trust proxy, express usa
+// el client real de X-Forwarded-For.
+app.set('trust proxy', 1);
+
 // Rate Limiting Configuration
 const globalLimiter = rateLimit({
   windowMs: 15 * 60 * 1000, // 15 minutes
-  limit: 100, // Limit each IP to 100 requests per `window`
+  // El dashboard dispara ~20-32 llamadas /api por carga (sin caché), así que el
+  // techo tiene que cubrir varias navegaciones de un usuario activo. Las rutas
+  // sensibles (login/register) tienen su propio authLimiter más estricto abajo.
+  limit: 1000, // por IP por ventana
   message: { message: 'Demasiadas peticiones desde esta IP, por favor intente de nuevo en 15 minutos' },
   standardHeaders: true,
   legacyHeaders: false,


### PR DESCRIPTION
## Problema
Usuarios reales reciben **429 Too Many Requests** en uso normal (categorías/medios/monedas vuelven vacíos, etc.).

## Causa raíz
1. **Cupo compartido entre todos los usuarios.** El front llama rutas relativas `/api/*` → `controlalo.com.ar` → Next.js las proxea al backend. Sin `trust proxy`, `req.ip` es la IP del proxy para *todos*, así que el "100 por IP" era un único cupo global para toda la app.
2. **Techo demasiado bajo.** El dashboard dispara ~20-32 llamadas `/api` por carga (sin caché). 100/15min se agota en 2-3 pantallas.

## Fix
- `app.set('trust proxy', 1)` → cada usuario keyea por su IP real (X-Forwarded-For).
- Techo global 100 → **1000** req/15min.
- `authLimiter` (login/register, 5/min) sin cambios.

## Seguimiento sugerido (no en este PR)
- El front refetchea definiciones 2 veces en el seeding de usuarios nuevos y usa `cache:'no-store'` en todo → reducir fan-out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)