### PR TITLE
MP: guardar el aviso en el historial del asistente

### DIFF
--- a/src/utils/mpSync.js
+++ b/src/utils/mpSync.js
@@ -11,6 +11,7 @@
 const db = require('../models');
 const mp = require('./mercadopago');
 const { sendText, sendTemplate } = require('../services/whatsapp/sender');
+const { normalizarTelefono } = require('./phoneUtils');
 
 // Si está configurado un template aprobado, el aviso de MP se manda como template
 // (se entrega aunque el usuario esté inactivo +24h). Si no, cae al texto libre
@@ -120,6 +121,14 @@ async function syncOne(userId, { force = false } = {}) {
                 if (user && user.telefono) {
                     try {
                         await avisarMovimiento(user.telefono, info);
+                        // Guardamos el aviso en el historial del asistente para que el agente
+                        // tenga el contexto de la conversación cuando el usuario responda.
+                        await db.ChatMessages.create({
+                            wa_id: normalizarTelefono(user.telefono),
+                            role: 'assistant',
+                            content: mensajeAviso(info),
+                            created_at: new Date()
+                        });
                     } catch (sendErr) {
                         console.error(`[mpSync] no se pudo avisar payment ${resourceId}:`, sendErr.response ? sendErr.response.data : sendErr.message);
                     }


### PR DESCRIPTION
Cuando se detecta un movimiento MP y se avisa por WhatsApp, ahora se registra ese aviso como turno `assistant` en `ChatMessages` (keyed por wa_id normalizado).

Así el agente ve la pregunta previa ("¿A qué se debió?") en el historial cuando el usuario responde — antes solo tenía el contexto vía `mp_pendientes` en el system prompt. Los dos mecanismos juntos hacen el flujo más robusto.

Sin migración. Deploya junto con el cambio de env del template MP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)