### PR TITLE
Invitar a crear cuenta cuando escribe un no-usuario por WhatsApp

### DIFF
--- a/src/services/whatsapp/inboundHandler.js
+++ b/src/services/whatsapp/inboundHandler.js
@@ -51,6 +51,15 @@ async function handleEvent(body) {
 
           const userContext = await buildFromWaId(waId);
 
+          if (!userContext.userId) {
+            await sendText({
+              to: waId,
+              text: '¡Hola! 👋 Soy el asistente de *Controlalo*, tu app para controlar tus gastos.\n\nEste número todavía no está asociado a una cuenta. Creá la tuya gratis en 👉 https://controlalo.com.ar/ y registrá tu WhatsApp para empezar a cargar y consultar tus gastos directamente desde acá. 💸',
+              phoneNumberId
+            });
+            continue;
+          }
+
           let reply;
           try {
             reply = await chat({ waId, userText, userContext });


### PR DESCRIPTION
Si el `waId` entrante no corresponde a un usuario registrado, el handler ahora responde con un mensaje que invita a crear cuenta en https://controlalo.com.ar/ y corta antes de llamar al agente IA. Evita gastar tokens de OpenAI y operar con `userId` undefined.

🤖 Generated with [Claude Code](https://claude.com/claude-code)